### PR TITLE
Fix

### DIFF
--- a/lib/features/doctor_booking/views/widgets/doctor_booking_tabs.dart
+++ b/lib/features/doctor_booking/views/widgets/doctor_booking_tabs.dart
@@ -24,6 +24,12 @@ class DoctorBookingTabs extends StatelessWidget {
               List<DoctorBookingModel> filteredBookings;
 
               switch (index) {
+                case 0:
+                  // For 'All' tab, show all except cancelled appointments
+                  filteredBookings = allBookingModel
+                      .where((booking) => booking.status != 'cancelled')
+                      .toList();
+                  break;
                 case 1:
                   filteredBookings = allBookingModel
                       .where((booking) => booking.status == 'scheduled')

--- a/lib/features/doctor_booking/views/widgets/doctor_booking_tabs.dart
+++ b/lib/features/doctor_booking/views/widgets/doctor_booking_tabs.dart
@@ -25,7 +25,6 @@ class DoctorBookingTabs extends StatelessWidget {
 
               switch (index) {
                 case 0:
-                  // For 'All' tab, show all except cancelled appointments
                   filteredBookings = allBookingModel
                       .where((booking) => booking.status != 'cancelled')
                       .toList();


### PR DESCRIPTION
This pull request includes a minor update to the `DoctorBookingTabs` widget in `lib/features/doctor_booking/views/widgets/doctor_booking_tabs.dart`. The change adds a new case in the switch statement to filter bookings that are not canceled.

Filtering logic update:

* [`lib/features/doctor_booking/views/widgets/doctor_booking_tabs.dart`](diffhunk://#diff-eb39d8d2cf9ef0dc2f48ac21a49360aa45e0054bdfd94a838c4c28cf7e78fb0dR27-R31): Added a new case (`case 0`) in the switch statement to filter bookings where the status is not `'cancelled'`.